### PR TITLE
TOOLS-652 Remove pinned go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: go
 
-go:
-  - 1.7
-
 script:
   - ./publish.sh


### PR DESCRIPTION
due to: https://github.com/golang/go/issues/29233

pw @SharktheFire 
fyi @Jimdo/werkzeugschmiede 